### PR TITLE
Escape backslash

### DIFF
--- a/atom/language-rascal/grammars/rascal.cson
+++ b/atom/language-rascal/grammars/rascal.cson
@@ -59,7 +59,7 @@ repository:
   regex:
     patterns: [
       {
-        begin: "/(?!/|\*)"
+        begin: "/(?!/|\\*)"
         end: "/([dims]*)"
         endCaptures:
           "1":


### PR DESCRIPTION
Fixes #15 where the backslash was improperly escaped. Sorry about that.

/cc @ahmadsalim @DavyLandman 